### PR TITLE
fix enabling notifications

### DIFF
--- a/backend/api/src/endpoints/notif_subs.rs
+++ b/backend/api/src/endpoints/notif_subs.rs
@@ -26,6 +26,12 @@ pub async fn add_notif_sub_endpoint(
     State(state): RequestState,
     Json(body): Json<AddNotifSubEndpointBody>,
 ) -> Result<impl IntoResponse, ApiError> {
+    if body.endpoint.len() > 2000 {
+        return Err(ApiError::BadRequest(
+            "endpoint url must be shorter than 2000 characters".to_owned(),
+        ));
+    }
+
     let notification_sub = db::notification_subs::upsert(
         &state.db2,
         &user_id,

--- a/backend/db/migrations/20240208150703_notif_sub_endpoint_text.sql
+++ b/backend/db/migrations/20240208150703_notif_sub_endpoint_text.sql
@@ -1,0 +1,17 @@
+ALTER TABLE notification_subs
+ADD COLUMN new_endpoint TEXT;
+
+UPDATE notification_subs
+SET new_endpoint = endpoint;
+
+ALTER TABLE notification_subs
+DROP COLUMN endpoint;
+
+ALTER TABLE notification_subs
+RENAME COLUMN new_endpoint TO endpoint;
+
+ALTER TABLE notification_subs
+ALTER COLUMN endpoint SET NOT NULL;
+
+ALTER TABLE notification_subs
+ADD CONSTRAINT unique_endpoint UNIQUE (endpoint);


### PR DESCRIPTION
fix enabling notifications on browsers which generate longer than 255 length notification endpoint urls by migrating from varchar(255) column type to text column type and checking for unusually high url length. 255 length constraint was an accident to begin with. urls can most definitely be longer